### PR TITLE
fix: replace fragile datetime string slicing with robust parser

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -82,7 +82,12 @@ logger = logging.getLogger("database")
 
 
 def _parse_datetime(s: str) -> datetime:
-    """Parse a datetime string, truncating sub-microsecond precision if present."""
+    """Parse an ISO 8601 datetime string with the following normalizations:
+
+    - Strips leading/trailing whitespace
+    - Converts 'Z' timezone suffix to '+00:00' for Python 3.10 compatibility
+    - Truncates sub-microsecond precision (>6 fractional digits) to microseconds
+    """
     s = s.strip()
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
@@ -1001,12 +1006,22 @@ class Database(abc.ABC):
                 return None
             return int(res)
         elif res_type is datetime:
-            res = _one(_one(res))
+            if not res:
+                raise ValueError("Datetime query returned 0 rows, expected 1")
+            row = _one(res)
+            if not row:
+                raise ValueError("Datetime query row is empty, expected 1 column")
+            res = _one(row)
             if isinstance(res, str):
                 try:
                     res = _parse_datetime(res)
                 except ValueError:
-                    logger.error("Failed to parse datetime string returned by database: %r", res)
+                    logger.error(
+                        "Failed to parse datetime string returned by database %s: %r (sql: %s)",
+                        self.name,
+                        res,
+                        sql_code,
+                    )
                     raise
             return res
         elif res_type is tuple:

--- a/tests/test_datetime_parsing.py
+++ b/tests/test_datetime_parsing.py
@@ -51,6 +51,15 @@ class TestParseDatetime:
         result = _parse_datetime("2022-06-03T12:24:35.123456789Z")
         assert result == datetime(2022, 6, 3, 12, 24, 35, 123456, tzinfo=timezone.utc)
 
+    def test_all_nines_nanoseconds_truncates_not_rounds(self):
+        result = _parse_datetime("2022-06-03 23:59:59.999999999")
+        assert result == datetime(2022, 6, 3, 23, 59, 59, 999999)
+
+    def test_negative_timezone_offset(self):
+        result = _parse_datetime("2022-06-03T12:24:35-05:00")
+        expected_tz = timezone(timedelta(hours=-5))
+        assert result == datetime(2022, 6, 3, 12, 24, 35, tzinfo=expected_tz)
+
     def test_trailing_dot_raises(self):
         with pytest.raises(ValueError):
             _parse_datetime("2022-06-03T12:24:35.")


### PR DESCRIPTION
## Summary
- Replace hardcoded `res[:23]` truncation in `base.py` with a `_parse_datetime()` helper that truncates sub-microsecond precision to 6 digits before calling `fromisoformat()`
- Preserves microsecond precision (previously truncated to milliseconds) and handles variable-length fractional seconds, timezone suffixes, and trailing whitespace
- Add unit tests covering standard, millisecond, no-fractional, nanosecond, whitespace, timezone, and invalid input cases

Closes #6

## Test plan
- [x] `uv run python -m pytest tests/test_datetime_parsing.py -v` — 7/7 new tests pass
- [x] `uv run python -m pytest tests/test_query.py -v` — 16/16 existing tests pass
- [x] No remaining `res[:23]` in `base.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)