### PR TITLE
fix: register CTE schema correctly when params rename columns

### DIFF
--- a/data_diff/queries/ast_classes.py
+++ b/data_diff/queries/ast_classes.py
@@ -636,8 +636,10 @@ class Cte(ExprNode, ITable):
     @property
     def schema(self) -> Schema:
         s = self.table.schema
-        if s is None or not self.params:
+        if not self.params:
             return s
+        if s is None:
+            raise QueryBuilderError(f"CTE params were provided ({self.params!r}) but the source table has no schema")
         if len(self.params) != len(s):
             raise QueryBuilderError(
                 f"CTE params length ({len(self.params)}) does not match source schema length ({len(s)})"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -236,6 +236,17 @@ class TestQuery(unittest.TestCase):
         with self.assertRaises(QueryBuilderError):
             _ = ct.schema
 
+        # Params on a schema-less source raises QueryBuilderError
+        t = table("a")
+        ct = cte(t.select(this.x), params=["renamed"])
+        with self.assertRaises(QueryBuilderError):
+            _ = ct.schema
+
+        # Empty params list passes through source schema unchanged
+        t = table("a", schema=CaseSensitiveDict({"x": int}))
+        ct = cte(t.select(this.x), params=[])
+        assert ct.schema == t.schema
+
     def test_funcs(self):
         c = Compiler(MockDatabase())
         t = table("a")


### PR DESCRIPTION
## Summary
- Fix `Cte.schema` to reflect renamed column names when `params` are provided, instead of passing through the original source column names
- Add param count mismatch validation that raises `QueryBuilderError`
- Preserve schema type (case sensitivity) through the renaming

Closes #9

## Test plan
- [x] `test_cte_schema`: non-parameterized CTE passes through source schema unchanged
- [x] `test_cte_schema`: parameterized CTE reflects renamed columns with correct types
- [x] `test_cte_schema`: param count mismatch raises `QueryBuilderError`
- [x] `test_cte_schema`: schema type (case sensitivity) is preserved
- [x] All 17 tests in `test_query.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)