### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ docker-compose-local.yml
 
 # Worktrees
 .worktrees/
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` directory to `.gitignore` to exclude Claude Code local config from version control

## Test plan
- [x] Verify `.claude/` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)